### PR TITLE
Set preserve3d on IsoGrid main element optional

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -592,9 +592,10 @@
 					}
 				}
 			});
-			
+
 			new IsoGrid(document.querySelector('.isolayer--deco2'), {
 				perspective: 3000,
+				preserve3d: false,
 				transform : 'translateY(-150px) rotateX(55deg) rotateZ(-45deg)',
 				stackItemsAnimation : {
 					properties : function(pos) {
@@ -614,7 +615,7 @@
 					}
 				}
 			});
-			
+
 			new IsoGrid(document.querySelector('.isolayer--deco3'), {
 				transform : 'translateX(40vw) translateY(100px) rotateX(15deg) rotateY(0) rotateZ(40deg)',
 				stackItemsAnimation : {
@@ -633,7 +634,7 @@
 					}
 				}
 			});
-			
+
 			new IsoGrid(document.querySelector('.isolayer--deco4'), {
 				perspective: 3000,
 				transform : 'translate3d(-200px,-200px,0) scale3d(0.8,0.8,1) rotateY(45deg) rotateZ(-10deg)',

--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,7 @@
  *
  * Licensed under the MIT license.
  * http://www.opensource.org/licenses/mit-license.php
- * 
+ *
  * Copyright 2016, Codrops
  * http://www.codrops.com
  */
@@ -64,24 +64,24 @@
 	/**********************************************/
 
 	var docElem = window.document.documentElement;
-	
+
 	// some helper functions
 	function scrollY() { return window.pageYOffset || docElem.scrollTop; }
 	function extend( a, b ) {
-		for( var key in b ) { 
+		for( var key in b ) {
 			if( b.hasOwnProperty( key ) ) {
 				a[key] = b[key];
 			}
 		}
 		return a;
 	}
-	
+
 	/**
 	 * Isometric grid obj
 	 */
 	function IsoGrid(el, options) {
 		this.isolayerEl = el;
-		
+
 		this.options = extend( {}, this.options );
 		extend( this.options, options );
 
@@ -90,7 +90,7 @@
 		// grid items
 		this.gridItems = [].slice.call(this.gridEl.querySelectorAll('.grid__item'));
 		this.gridItemsTotal = this.gridItems.length;
-		
+
 		this.didscroll = false;
 
 		this._init();
@@ -101,6 +101,8 @@
 		type: 'static',
 		// grid perspective value
 		perspective: 0,
+		// preserve-3d on container element
+		preserve3d: true,
 		// grid transform
 		transform: '',
 		// each grid item animation (for the subitems)
@@ -122,7 +124,7 @@
 			}
 		},
 		// callback for loaded grid
-		onGridLoaded : function() { return false; }	
+		onGridLoaded : function() { return false; }
 	};
 
 	IsoGrid.prototype._init = function() {
@@ -134,22 +136,25 @@
 				itemSelector: '.grid__item',
 				isFitWidth : true
 			});
-			
+
 			// the isolayer div element will be positioned fixed and will have a transformation based on the values defined in the HTML (data-attrs for the isolayer div element)
 			if( self.options.type === 'scrollable' ) {
-				self.isolayerEl.style.position = 'fixed';	
+				self.isolayerEl.style.position = 'fixed';
 			}
-			
-			self.isolayerEl.style.WebkitTransformStyle = self.isolayerEl.style.transformStyle = 'preserve-3d';
+
+			// assign preserve-3d to isolayer div element
+			if (self.options.preserve3d) {
+				self.isolayerEl.style.WebkitTransformStyle = self.isolayerEl.style.transformStyle = 'preserve-3d';
+			}
 
 			var transformValue = self.options.perspective != 0 ? 'perspective(' + self.options.perspective + 'px) ' + self.options.transform : self.options.transform;
 			self.isolayerEl.style.WebkitTransform = self.isolayerEl.style.transform = transformValue;
-			
+
 			// create the div element that will force the height for scrolling
 			if( self.options.type === 'scrollable' ) {
 				self._createPseudoScroller();
 			}
-			
+
 			// init/bind events
 			self._initEvents();
 
@@ -178,7 +183,7 @@
 		// insert it inside the main container (same level of isolayerEl)
 		this.isolayerEl.parentNode.insertBefore(this.pseudoScrollerEl, this.isolayerEl);
 		// set the height of the pseudoScroller (grid´s height + additional space between the top of the rotated isolayerEl and the page - value set for the translation on the Y axis)
-		this.pseudoScrollerEl.style.height = this.gridEl.offsetHeight + getComputedTranslateY(this.isolayerEl) * Math.sqrt(2) + 'px';	
+		this.pseudoScrollerEl.style.height = this.gridEl.offsetHeight + getComputedTranslateY(this.isolayerEl) * Math.sqrt(2) + 'px';
 	};
 
 	/**
@@ -222,11 +227,11 @@
 	IsoGrid.prototype._expandSubItems = function(item) {
 		var self = this,
 			itemLink = item.querySelector('a'),
-			subItems = [].slice.call(itemLink.querySelectorAll('.layer')), 
+			subItems = [].slice.call(itemLink.querySelectorAll('.layer')),
 			subItemsTotal = subItems.length;
 
 		itemLink.style.zIndex = item.style.zIndex = this.gridItemsTotal;
-		
+
 		subItems.forEach(function(subitem, pos) {
 			dynamics.stop(subitem);
 			dynamics.animate(subitem, self.options.stackItemsAnimation.properties(pos), self.options.stackItemsAnimation.options(pos, subItemsTotal));


### PR DESCRIPTION
After open this awesome demo (like always) found that there were a weird render behaviour (at least) in Chrome. tested also in FF, Canary and Safari with similar (less or more) behaviours. 

So tried to solve. Maybe (probably) you have a better solution, but at least I share with you mine: 

> just made `transform-style: preserve-3d` on main Elem optional 

For the demos is only needed `false` in the second one inside `index2.html`

Hope it'll be helpful.

---

Here are some screens:
### before

Chrome
![chrome](https://cloud.githubusercontent.com/assets/784056/15543527/852ee8fa-2295-11e6-9933-7b54a98d1892.gif)

Canary: 
![canary](https://cloud.githubusercontent.com/assets/784056/15543706/3dd56b86-2296-11e6-8ed6-06cb1d9dd40e.gif)

FF:
![ff](https://cloud.githubusercontent.com/assets/784056/15543711/43418fa0-2296-11e6-85ae-7b42810d1a03.gif)

Safari:
![safari](https://cloud.githubusercontent.com/assets/784056/15543727/4e47f8da-2296-11e6-8ee6-9472e1cb803f.gif)
### after

Chrome:
![chrome](https://cloud.githubusercontent.com/assets/784056/15543734/596a5d48-2296-11e6-86fe-b171901fc6c2.gif)

Canary:
![canary](https://cloud.githubusercontent.com/assets/784056/15543739/5d424db8-2296-11e6-841a-85b1b2dd1fa4.gif)

FF:
![ff](https://cloud.githubusercontent.com/assets/784056/15543744/61228f88-2296-11e6-8d94-d58ad771f081.gif)

Safari:
![safari](https://cloud.githubusercontent.com/assets/784056/15543749/65f20232-2296-11e6-979b-cfd8f134b2c5.gif)
